### PR TITLE
Fixed name to comply with autoloading standards.

### DIFF
--- a/src/assetbundles/bs4/ThemeTagsAsset.php
+++ b/src/assetbundles/bs4/ThemeTagsAsset.php
@@ -3,7 +3,7 @@ namespace buttflattery\formwizard\assetbundles\bs4;
 
 use buttflattery\formwizard\assetbundles\bs4\ThemeBase;
 
-class ThemeNoteBookAsset extends ThemeBase
+class ThemeTagsAsset extends ThemeBase
 {
 
     /**


### PR DESCRIPTION
There was a mismatch in the filename and the class name, hence it will have autoloading errors in Composer.